### PR TITLE
Set timezone in MailingListTest

### DIFF
--- a/niord-core/src/test/java/org/niord/core/MailingListTest.java
+++ b/niord-core/src/test/java/org/niord/core/MailingListTest.java
@@ -22,13 +22,14 @@ import org.niord.core.mailinglist.ScheduledExecutionTimeUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Mailing list tests
  */
-public class MailingLIstTest {
+public class MailingListTest {
 
     @Test
     public void testScheduledExecutionTime() throws Exception {
@@ -36,6 +37,7 @@ public class MailingLIstTest {
         String timeZone = "Europe/Copenhagen";
 
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
+        sdf.setTimeZone(TimeZone.getTimeZone(timeZone));
 
         Date nextExecutionTime = ScheduledExecutionTimeUtil
                 .computeNextExecutionTime(


### PR DESCRIPTION
`MailingListTest` failed when run in a non-CET timezone (in my case AEDT). Fix is to set the timezone on the `SimpleDateFormat` instance.

Also fixed test name which had a typo.