### PR TITLE
remove resource suffixes .gml, .xsd from S124RestService

### DIFF
--- a/niord-s124/src/main/java/org/niord/s124/S124RestService.java
+++ b/niord-s124/src/main/java/org/niord/s124/S124RestService.java
@@ -72,7 +72,7 @@ public class S124RestService {
             tags = {"S-124"}
     )
     @GET
-    @Path("/{messageId}.gml")
+    @Path("/messages/{messageId}")
     @Produces({"application/gml+xml;charset=UTF-8"})
     public Response s124MessageDetails(
             @ApiParam(value = "The message UID or short ID", example = "NW-061-17")
@@ -138,7 +138,7 @@ public class S124RestService {
      * {@inheritDoc}
      */
     @GET
-    @Path("/{file}.xsd")
+    @Path("/xsds/{file}")
     @Produces({"text/xml;charset=UTF-8"})
     public Response xsdFile(
             @PathParam("file") String file


### PR DESCRIPTION
I'd like to change the S124 resource paths to conform with REST API conventions (as I have interpreted them after a bit of browsing, unfortunately no official standards re naming that I could find!) but particularly for compatibility with AWS API Gateway. 

In particular the use of extensions in the path like `/{messageId}.gml` and `/{file}.xsd` is not supported by API Gateway.

I've chosen to rename the paths as follows:
* `/{messageId}.gml` -> `/messages/{messageId}`
* `/{file}.xsd` -> `/xsds/{file}`

You'll notice I follow collection conventions (a collection name that is pluralised) taken from these popular REST API Guides:
* http://zalando.github.io/restful-api-guidelines/#resources
* https://cloud.google.com/apis/design/resource_names

I think the question of compatibility of the API with a big provider like AWS and other providers is worth considering carefully. An API Gateway + Lambda solution with AWS is ridiculously cheap to run, scales well, is highly available, secure, monitored, logged and withstands attacks well. 
 
A quick example is that an xml rest service that AMSA has deployed to API Gateway is handling 200,000 requests a month with a typical response being order of MBs at a running cost of ~$20/year. AWS manages all of the underlying infrastructure so we spend no time on platform updates and security fixes for example.