### PR TITLE
Add messages s-124 method to rest api

### DIFF
--- a/niord-core/src/main/java/org/niord/core/message/Message.java
+++ b/niord-core/src/main/java/org/niord/core/message/Message.java
@@ -103,6 +103,8 @@ import java.util.stream.Stream;
                         + " msg.publishDateFrom between :fromDate and :toDate and msg.number is not null"),
         @NamedQuery(name="Message.separatePageUids",
                 query="SELECT msg.uid FROM Message msg where msg.separatePage = true and msg.uid in (:uids)"),
+        @NamedQuery(name="Message.findByLastUpdatedTimeBetween",
+                query="SELECT msg.uid FROM Message msg where msg.updated >= :from and msg.updated < :to and msg.messageSeries in (:series)")
 })
 @SuppressWarnings("unused")
 public class Message extends VersionedEntity<Integer> implements ILocalizable<MessageDesc> {

--- a/niord-core/src/main/java/org/niord/core/message/MessageService.java
+++ b/niord-core/src/main/java/org/niord/core/message/MessageService.java
@@ -750,8 +750,7 @@ public class MessageService extends BaseService {
                 .setMaxResults(maxCount)
                 .getResultList();
     }
-
-
+    
     /**
      * Computes the auto-generated message fields for the given message template
      *
@@ -960,6 +959,14 @@ public class MessageService extends BaseService {
         messages.sort(Comparator.comparingInt(m -> ids.indexOf(m.getId())));
 
         return messages;
+    }
+    
+    public List<String> messagesLastUpdatedBetween(Date fromInclusive, Date toExclusive) {
+        return em.createNamedQuery("Message.findByLastUpdatedTimeBetween", String.class)
+                   .setParameter("series", domainService.currentDomain().getMessageSeries())
+                   .setParameter("from", fromInclusive)
+                   .setParameter("to", toExclusive)
+                   .getResultList();
     }
 
 
@@ -1489,4 +1496,5 @@ public class MessageService extends BaseService {
     public void updateMessageFromTempRepoFolder(SystemMessageVo message) throws IOException {
         repositoryService.updateRepoFolderFromTempEditFolder(message);
     }
+    
 }

--- a/niord-s124/src/main/java/org/niord/s124/S124RestService.java
+++ b/niord-s124/src/main/java/org/niord/s124/S124RestService.java
@@ -15,11 +15,12 @@
  */
 package org.niord.s124;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
@@ -36,9 +37,15 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.io.StringWriter;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 /**
  * A public REST API for accessing messages as S-124 GML.
@@ -111,7 +118,26 @@ public class S124RestService {
                     .build();
         }
     }
-
+    
+    //TODO add @ApiOperation
+    @GET
+    @Path("/messages")
+    @Produces("application/json;charset=UTF-8")
+    public List<String> s124messagesLastUpdatedBetween(
+            @PathParam("fromInclusive") String fromTimestampInclusive, 
+            @PathParam("toExclusive") @DefaultValue("9999-01-01T12:00Z") String toTimestampExclusive) throws ParseException {
+        ISO8601DateFormat df = new ISO8601DateFormat();
+        Date fromInclusive;
+        Date toExclusive;
+        try {
+            fromInclusive = df.parse(fromTimestampInclusive);
+            toExclusive = df.parse(toTimestampExclusive);
+        } catch (ParseException e) {
+            log.error("from or to parameter should be a timestamp as per ISO 8601");
+            throw e;
+        }
+        return s124Service.messagesLastUpdatedBetween(fromInclusive, toExclusive);
+    }
 
     /** Arghh, for some insane reason, this function does not work properly :-( **/
     public static String prettyPrint(String input) {
@@ -165,5 +191,4 @@ public class S124RestService {
                     .build();
         }
     }
-
 }

--- a/niord-s124/src/main/java/org/niord/s124/S124Service.java
+++ b/niord-s124/src/main/java/org/niord/s124/S124Service.java
@@ -16,24 +16,31 @@
 package org.niord.s124;
 
 
-import freemarker.cache.ClassTemplateLoader;
-import freemarker.template.Configuration;
-import freemarker.template.Template;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
 import org.niord.core.NiordApp;
 import org.niord.core.geojson.GeoJsonUtils;
 import org.niord.core.message.Message;
+import org.niord.core.message.MessageSearchParams;
 import org.niord.core.message.MessageService;
 import org.niord.core.message.vo.SystemMessageVo;
 import org.niord.model.message.MainType;
 import org.niord.model.message.ReferenceVo;
+import org.niord.model.message.Status;
 
-import javax.ejb.Stateless;
-import javax.inject.Inject;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
 
 
 /**
@@ -158,4 +165,9 @@ public class S124Service {
             this.msg = msg;
         }
     }
+
+    public List<String> messagesLastUpdatedBetween(Date fromInclusive, Date toExclusive) {
+        return messageService.messagesLastUpdatedBetween(fromInclusive, toExclusive);
+    }
+
 }


### PR DESCRIPTION
Fixes #92 

I'd like a method to find all updates within a window of time that pertain to S-124. This method might be called repeatedly on some interval with advancing time windows to gather up all new and updated S-124 messages (returning just the ids).

The new method signature is below. Timestamps would be expected to be in ISO 8601 format.

```java
@GET
    @Path("/messages")
    @Produces("application/json;charset=UTF-8")
    public List<String> s124messagesLastUpdatedBetween(
            @PathParam("fromInclusive") String fromTimestampInclusive, 
            @PathParam("toExclusive") 
            @DefaultValue("9999-01-01T12:00Z") String toTimestampExclusive)
```

Excuse the shuffle of the imports. I was a bit forgetful and organized imports with Eclipse.
