### PR TITLE
Fixing the tag search immutable set issue

### DIFF
--- a/niord-core/src/main/java/org/niord/core/message/MessageTagService.java
+++ b/niord-core/src/main/java/org/niord/core/message/MessageTagService.java
@@ -209,7 +209,7 @@ public class MessageTagService extends BaseService {
         criteriaHelper.equals(tagRoot.get("locked"), params.getLocked());
 
         // Type filtering
-        Set<MessageTagType> types = params.getTypes() != null ? params.getTypes() : new HashSet<>();
+        Set<MessageTagType> types = params.getTypes() != null ? new HashSet<>(params.getTypes()) : new HashSet<>();
         if (types.isEmpty()) {
             types.add(PUBLIC);
             types.add(DOMAIN);


### PR DESCRIPTION
I also found another issue where the tags are read into an immutable set which then cannot be altered.

This causes errors when opening the tag dialog in the messages view of the front-end.

A simple constructor there seems to resolve the issue.