### PR TITLE
Allowing the message param filter endpoints

### DIFF
--- a/niord-web/src/main/java/org/niord/web/MessageParamFilterRestService.java
+++ b/niord-web/src/main/java/org/niord/web/MessageParamFilterRestService.java
@@ -26,6 +26,7 @@ import org.niord.core.user.UserService;
 import org.niord.core.message.vo.MessageParamFilterVo;
 import org.slf4j.Logger;
 
+import javax.annotation.security.PermitAll;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
 @Path("/filters")
 @Stateless
 @SecurityDomain("keycloak")
+@PermitAll
 public class MessageParamFilterRestService {
 
     @Inject
@@ -99,7 +101,7 @@ public class MessageParamFilterRestService {
 
     /** Creates a new filter from the given template */
     @POST
-    @Path("/filter/")
+    @Path("/filter")
     @Consumes("application/json;charset=UTF-8")
     @Produces("application/json;charset=UTF-8")
     @GZIP


### PR DESCRIPTION
When trying to save a new custom filter in the front-end message view, we now get internal server errors due to the permission restrictions. This might be cause by the keycloak upgrade so I guess we need to permit all endpoints as in other REST controllers. Each call then makes sure the user is valid and logged in (kind of stranger way of authorization) but that's how it works!